### PR TITLE
Allow building and publishing of docs on dev

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -34,7 +34,7 @@ defmodule Turbojpeg.MixProject do
       {:shmex, "~> 0.2.0"},
       {:bundlex, "~> 0.2.6"},
       {:membrane_core, "~> 0.5.0"},
-      {:ex_doc, "~> 0.21.3", only: [:docs]}
+      {:ex_doc, "~> 0.21.3", only: [:dev], runtime: false}
     ]
   end
 


### PR DESCRIPTION
`MIX_ENV=docs` was needed to build and publish docs. I moved it to the
dev environment so we wouldn't need a special environment for tests. I
also added `runtime: false` to make sure that it wouldn't do anything
when starting the application. This also saves time by not having to
recompile just to produces documentation. If dev is already compiled you
don't have to wait again in a new environment.

Amos King @adkron <amos@binarynoggin.com>